### PR TITLE
Use resolve-uri library for NCList

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,14 +4,14 @@ on: push
 
 jobs:
   test:
-    name: Lint, build, and test on node 14.x and ubuntu-latest
+    name: Lint, build, and test on node 20.x and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 14.x
+          node-version: 20.x
       - name: Install deps (with cache)
         uses: bahmutov/npm-install@v1
       - name: Lint codebase

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Read legacy JBrowse 1 nested containment list JSON.
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/GMOD/nclist-js/push.yml?branch=master)](https://github.com/GMOD/nclist-js/actions)
 [![Coverage Status](https://img.shields.io/codecov/c/github/GMOD/nclist-js/master.svg?style=flat-square)](https://codecov.io/gh/GMOD/nclist-js/branch/master)
-[![NPM version](https://img.shields.io/npm/v/@gmod/nclist.svg?logo=npm&style=flat-square)](https://npmjs.org/package/@gmod/nclist)
+[![NPM version](https://img.shields.io/npm/v/@gmod/nclist.svg?logo=npm\&style=flat-square)](https://npmjs.org/package/@gmod/nclist)
 
 ## Usage
 
@@ -40,12 +40,12 @@ import NCList from '@gmod/nclist'
 
 #### Table of Contents
 
-- [NCListStore](#ncliststore)
-  - [Parameters](#parameters)
-  - [getRegionFeatureDensities](#getregionfeaturedensities)
-    - [Parameters](#parameters-1)
-  - [getFeatures](#getfeatures)
-    - [Parameters](#parameters-2)
+*   [NCListStore](#ncliststore)
+    *   [Parameters](#parameters)
+    *   [getRegionFeatureDensities](#getregionfeaturedensities)
+        *   [Parameters](#parameters-1)
+    *   [getFeatures](#getfeatures)
+        *   [Parameters](#parameters-2)
 
 ### NCListStore
 
@@ -54,14 +54,14 @@ lists held in JSON files that are lazily read.
 
 #### Parameters
 
-- `args` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** constructor args
+*   `args` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** constructor args
 
-  - `args.baseUrl` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** base URL for resolving relative URLs
-  - `args.urlTemplate` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Template string for
-    the root file of each reference sequence. The reference sequence
-    name will be interpolated into this string where `{refseq}` appears.
-  - `args.readFile` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** function to use for reading remote from URLs.
-  - `args.cacheSize` (optional, default `10`)
+    *   `args.baseUrl` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** base URL for resolving relative URLs
+    *   `args.urlTemplate` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Template string for
+        the root file of each reference sequence. The reference sequence
+        name will be interpolated into this string where `{refseq}` appears.
+    *   `args.readFile` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** function to use for reading remote from URLs.
+    *   `args.cacheSize`   (optional, default `10`)
 
 #### getRegionFeatureDensities
 
@@ -69,13 +69,13 @@ fetch binned counts of feature coverage in the given region.
 
 ##### Parameters
 
-- `query` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**&#x20;
+*   `query` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**&#x20;
 
-  - `query.refName` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** reference sequence name
-  - `query.start` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** region start
-  - `query.end` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** region end
-  - `query.numBins` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** number of bins desired in the feature counts
-  - `query.basesPerBin` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** number of bp desired in each feature counting bin
+    *   `query.refName` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** reference sequence name
+    *   `query.start` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** region start
+    *   `query.end` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** region end
+    *   `query.numBins` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** number of bins desired in the feature counts
+    *   `query.basesPerBin` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** number of bp desired in each feature counting bin
 
 Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** as:
 `{ bins: hist, stats: statEntry }`
@@ -87,8 +87,8 @@ yielding feature objects.
 
 ##### Parameters
 
-- `args` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**&#x20;
+*   `args` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**&#x20;
 
-  - `args.refName` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** reference sequence name
-  - `args.start` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** start of region. 0-based half-open.
-  - `args.end` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** end of region. 0-based half-open.
+    *   `args.refName` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** reference sequence name
+    *   `args.start` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** start of region. 0-based half-open.
+    *   `args.end` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** end of region. 0-based half-open.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
+    "@jridgewell/resolve-uri": "^3.1.2",
     "abortable-promise-cache": "^1.0.1",
     "quick-lru": "^4.0.0"
   },

--- a/src/feature_store.ts
+++ b/src/feature_store.ts
@@ -5,7 +5,7 @@ import AbortablePromiseCache from 'abortable-promise-cache'
 import GenericNCList from './nclist'
 import ArrayRepr from './array_representation'
 import LazyArray from './lazy_array'
-import { readJSON } from './util'
+import { newURL, readJSON } from './util'
 
 function idfunc() {
   return this._uniqueID
@@ -63,7 +63,7 @@ export default class NCListStore {
   }
 
   fetchDataRoot(refName) {
-    const url = new URL(
+    const url = newURL(
       this.urlTemplates.root.replace(/{\s*refseq\s*}/g, refName),
       this.baseUrl,
     )

--- a/src/lazy_array.ts
+++ b/src/lazy_array.ts
@@ -1,7 +1,7 @@
 //@ts-nocheck
 import QuickLRU from 'quick-lru'
 import AbortablePromiseCache from 'abortable-promise-cache'
-import { readJSON } from './util'
+import { newURL, readJSON } from './util'
 
 /**
  * For a JSON array that gets too large to load in one go, this class
@@ -63,7 +63,7 @@ export default class LazyArray {
   async getChunk(chunkNumber) {
     let url = this.urlTemplate.replace(/\{Chunk\}/gi, chunkNumber)
     if (this.baseUrl) {
-      url = new URL(url, this.baseUrl)
+      url = newURL(url, this.baseUrl)
     }
     const data = await readJSON(url, this.readFile)
     return [chunkNumber, data]

--- a/src/nclist.ts
+++ b/src/nclist.ts
@@ -1,7 +1,7 @@
 //@ts-nocheck
 import QuickLRU from 'quick-lru'
 import AbortablePromiseCache from 'abortable-promise-cache'
-import { readJSON } from './util'
+import { newURL, readJSON } from './util'
 
 export default class NCList {
   constructor({ readFile, cacheSize = 100 }) {
@@ -49,7 +49,7 @@ export default class NCList {
   }
 
   readChunkItems(chunkNum) {
-    const url = new URL(
+    const url = newURL(
       this.lazyUrlTemplate.replace(/\{Chunk\}/gi, chunkNum),
       this.baseURL,
     )

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,6 @@
 //@ts-nocheck
+import resolve from '@jridgewell/resolve-uri'
+
 export async function readJSON(url, readFile, options = {}) {
   const { defaultContent = {} } = options
   let str
@@ -9,7 +11,8 @@ export async function readJSON(url, readFile, options = {}) {
     if (
       error.code === 'ENOENT' ||
       error.status === 404 ||
-      error.message.includes('404')
+      error.message.includes('404') ||
+      error.message.includes('ENOENT')
     ) {
       return defaultContent
     }
@@ -18,3 +21,7 @@ export async function readJSON(url, readFile, options = {}) {
 }
 
 export function foo() {}
+
+export function newURL(arg: string, base?: string = '.') {
+  return resolve(arg, base)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -586,7 +586,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@jridgewell/resolve-uri@^3.1.0":
+"@jridgewell/resolve-uri@^3.1.0", "@jridgewell/resolve-uri@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==


### PR DESCRIPTION
See @jridgewell/resolve-uri https://www.npmjs.com/package/@jridgewell/resolve-uri
 
This will allow jbrowse to update from 0.x branch of nclist-js to 1.x branch and does not require node.js polyfills (was previously in 0.x branch reliant on the `url` nodejs module)